### PR TITLE
Switch to GitHub-integrated release creator

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+# release.yml
+
+changelog:
+  exclude:
+    labels:
+      - No-changelog
+      - Type: invalid
+  categories:
+  - title: Breaking Changes 🛠
+    labels:
+    - Version: major
+  - title: Exciting New Features 🎉
+    labels:
+    - Version: minor
+  - title: "🐛 Bug fixes"
+    labels:
+      - "Type: bug"
+  - title: "📖 Docs"
+    labels:
+      - "Updates: documentation"
+  - title: "⚙️ Tests"
+    labels:
+      - "Type: tests"
+  - title: "🔧 Chores"
+    labels:
+      - "Updates: dependencies"
+      - "Updates: npm deps"
+  - title: Other Changes
+    labels:
+       - "*"


### PR DESCRIPTION
<!--
    Thank you for opening this Pull request!
    Please make sure to read the info in this PR and to
    provide all nessecary information.

    Not following the template may result in your PR
    being closed without warning!
-->

## Checks
<!-- Please "check" the below options by replacing [ ] with [x] -->

I have...

- [x] Read and understood the [Contributing Guidelines][contributing]
- [ ] Updated any nessecary files such as the README.md and/or CHANGELOG.md.

## Type of Pull request
<!-- Please "check" the below options by replacing [ ] with [x] -->
<!-- ONLY select one option! -->

- [ ] **Minor Change**  
  This Pull request doesn't break existing configuration.
- [ ] **Major Change**  
  This Pull request will break existing configuration.
- [ ] **Bug fix**  
  This Pull request will fix a (critical) bug.
- [ ] **Documentation**  
  This Pull request only changes documentation (README.md, CHANGELOG.md, etc.)
- [x] **Other:** `Release system` <!-- Replace the __________ with what you changed -->

## Description

GitHub released a public beta for the automatic release creation.

- Blog Post: https://github.blog/changelog/2021-10-04-improvements-to-github-releases-public-beta/
- Documentation: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

Downside of this is, that it will essentially require us to manually update stuff like the version of the release and similar...

<!-- When your Pull request is related to an issue, mention the ID here -->
Closes #

<!-- Do not edit anything below this line! -->
[contributing]: https://github.com/Welcome-Bot/welcome-bot/blob/main/.github/CONTRIBUTING.md
